### PR TITLE
Fix video and model viewer

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: node

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-to-image-mod",
-  "version": "1.11.11-1",
+  "version": "1.11.11-2",
   "description": "Generates an image from a DOM node using HTML5 canvas and SVG. This is a fork which fixes #345 from original Repo (bubkoo/html-to-image) ",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/clone-node.ts
+++ b/src/clone-node.ts
@@ -74,7 +74,7 @@ async function cloneChildren<T extends HTMLElement>(
 ): Promise<T> {
   let children: T[] = []
 
-  if (isSlotElement(nativeNode) && nativeNode.assignedNodes) {
+  if (isSlotElement(nativeNode) && nativeNode.assignedNodes && nativeNode.assignedNodes().length > 0) {
     children = toArray<T>(nativeNode.assignedNodes())
   } else if (
     isInstanceOfElement(nativeNode, HTMLIFrameElement) &&

--- a/src/clone-node.ts
+++ b/src/clone-node.ts
@@ -13,7 +13,7 @@ async function cloneCanvasElement(canvas: HTMLCanvasElement) {
 }
 
 async function cloneVideoElement(video: HTMLVideoElement, options: Options) {
-  if (video.currentSrc) {
+  if (video.currentSrc && video.currentTime > 0) {
     const canvas = document.createElement('canvas')
     const ctx = canvas.getContext('2d')
     canvas.width = video.clientWidth

--- a/src/clone-node.ts
+++ b/src/clone-node.ts
@@ -13,7 +13,7 @@ async function cloneCanvasElement(canvas: HTMLCanvasElement) {
 }
 
 async function cloneVideoElement(video: HTMLVideoElement, options: Options) {
-  if (video.currentSrc && video.currentTime > 0) {
+  if (video.currentSrc && (video.poster == null || video.poster === '' || video.currentTime > 0)) {
     const canvas = document.createElement('canvas')
     const ctx = canvas.getContext('2d')
     canvas.width = video.clientWidth


### PR DESCRIPTION
### Description

The snapshot of a video with poster that was never played was empty. Now, if the `currentTime` of the video is 0 and there is a poster, the snapshot is based on the poster.

When a `slot` tag does not have `assignedNodes`, the snapshot does not take child nodes into account. The model-viewer (https://modelviewer.dev/) which displays 3D models could therefore not be displayed in a snapshot. Now, if the `slot` tag does not have `assignedNodes`, the snapshot uses the `childNodes`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
